### PR TITLE
Add option to save preferences into local storage, issue #82

### DIFF
--- a/background.js
+++ b/background.js
@@ -1,8 +1,8 @@
-let prefernce = {}
+let Preference = {}
 const fontBtns = document.getElementsByClassName("fontSize");
 for (let i = 0; i < fontBtns.length; i++) {
   fontBtns[i].addEventListener("click", function (e) {
-    prefernce.fontSize = e.target.innerText;
+    Preference.fontSize = e.target.innerText;
     console.log("Hi");
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, {
@@ -15,7 +15,7 @@ for (let i = 0; i < fontBtns.length; i++) {
 const fontStyleBtns = document.getElementsByClassName("fontStyle");
 for (let i = 0; i < fontStyleBtns.length; i++) {
   fontStyleBtns[i].addEventListener("click", function (e) {
-    prefernce.fontStyle = e.target.innerText;
+    Preference.fontStyle = e.target.innerText;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, {
         action: "fontStyle",
@@ -28,7 +28,7 @@ for (let i = 0; i < fontStyleBtns.length; i++) {
 const images = document.getElementsByClassName("img-remmover");
 for (let i = 0; i < images.length; i++) {
   images[i].addEventListener("click", function (e) {
-    prefernce.image = false;
+    Preference.image = false;
     console.log("clicked");
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, { action: "image" });
@@ -39,7 +39,7 @@ for (let i = 0; i < images.length; i++) {
 const imageAdd = document.getElementsByClassName("img-add");
 for (let i = 0; i < imageAdd.length; i++) {
   imageAdd[i].addEventListener("click", function (e) {
-    prefernce.image = true;
+    Preference.image = true;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, { action: "imageAdd" });
     });
@@ -86,7 +86,7 @@ for (let i = 0; i < textToSpeechStop.length; i++) {
 const links = document.getElementsByClassName("link");
 for (let i = 0; i < links.length; i++) {
   links[i].addEventListener("click", function (e) {
-    prefernce.linkHighlight = true;
+    Preference.linkHighlight = true;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, { action: "link-highlight" });
     });
@@ -98,7 +98,7 @@ for (let i = 0; i < links.length; i++) {
 const removeLinkHighlight = document.getElementsByClassName("remove-link-hg");
 for (let i = 0; i < links.length; i++) {
   removeLinkHighlight[i].addEventListener("click", function (e) {
-    prefernce.linkHighlight = false;
+    Preference.linkHighlight = false;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, { action: "link-highlight-remove" });
     });
@@ -120,7 +120,7 @@ const backgroundColorChanger = document.getElementById(
 backgroundColorChanger.addEventListener("submit", function (e) {
   
   e.preventDefault();
-  prefernce.backgroundColor = e.target.color.value;
+  Preference.backgroundColor = e.target.color.value;
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     chrome.tabs.sendMessage(tabs[0].id, {
       action: "backgroundColor",
@@ -132,7 +132,7 @@ backgroundColorChanger.addEventListener("submit", function (e) {
 document
   .getElementsByClassName("revert-background-color")[0]
   .addEventListener("click", function (e) {
-    prefernce.backgroundColor = false;
+    Preference.backgroundColor = false;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, {
         action: "revert-background-color",
@@ -143,7 +143,7 @@ document
 const fontColorChanger = document.getElementById("fontColorChanger");
 fontColorChanger.addEventListener("submit", function (e) {
   e.preventDefault();
-  prefernce.fontColor = e.target.color.value;
+  Preference.fontColor = e.target.color.value;
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     chrome.tabs.sendMessage(tabs[0].id, {
       action: "fontColor",
@@ -155,7 +155,7 @@ fontColorChanger.addEventListener("submit", function (e) {
 const highlightPara = document.getElementsByClassName("para-highlighter");
 for (let i = 0; i < highlightPara.length; i++) {
   highlightPara[i].addEventListener("click", function () {
-    prefernce.paraHighlight = true;
+    Preference.paraHighlight = true;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, { action: "para-highlighter" });
     });
@@ -169,7 +169,7 @@ const removeHighlightPara = document.getElementsByClassName(
 );
 for (let i = 0; i < removeHighlightPara.length; i++) {
   removeHighlightPara[i].addEventListener("click", function () {
-    prefernce.paraHighlight = false;
+    Preference.paraHighlight = false;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, {
         action: "para-highlighter-remove",
@@ -260,7 +260,7 @@ for (let i = 0; i < speakerHelper.length; i++) {
 
 
 function handleZoom(zoomVal) {
-  prefernce.zoomVal = zoomVal;
+  Preference.zoomVal = zoomVal;
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     chrome.tabs.sendMessage(tabs[0].id, {
       action: "zoomPage",
@@ -323,52 +323,52 @@ for (let i = 0; i < italics_underscore_reset.length; i++) {
   });
 }
 
-const savePrefernceBtn = document
-     .getElementById("savePrefernceBtn")
-     .addEventListener("click", savePrefernce);
-function savePrefernce(e) {
-     //will save prefernces
+const savePreferenceBtn = document
+     .getElementById("savePreferenceBtn")
+     .addEventListener("click", savePreference);
+function savePreference(e) {
+     //will save Preferences
      e.preventDefault();
 
-     localStorage.setItem("dinoPrefernces", JSON.stringify(prefernce));
+     localStorage.setItem("dinoPreferences", JSON.stringify(Preference));
 }
-document.getElementById("clearPrefernceBtn").addEventListener("click", (e) => {
+document.getElementById("clearPreferenceBtn").addEventListener("click", (e) => {
      e.preventDefault();
-     prefernce = {};
-     localStorage.setItem("dinoPrefernces", JSON.stringify(prefernce));
-}); // will clear all your prefernce
+     Preference = {};
+     localStorage.setItem("dinoPreferences", JSON.stringify(Preference));
+}); // will clear all your Preference
 
 document
      .getElementById("localStorageToggler")
      .addEventListener("click", (e) => {
-          let localPrefernce = JSON.parse(
-               localStorage.getItem("dinoPrefernces"),
+          let localPreference = JSON.parse(
+               localStorage.getItem("dinoPreferences"),
           );
 
-          if (localPrefernce) {
-               if (localPrefernce.fontSize) {
+          if (localPreference) {
+               if (localPreference.fontSize) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {
                               chrome.tabs.sendMessage(tabs[0].id, {
                                    action: "fontSize",
-                                   fontSize: localPrefernce.fontSize,
+                                   fontSize: localPreference.fontSize,
                               });
                          },
                     );
                }
-               if (localPrefernce.fontStyle) {
+               if (localPreference.fontStyle) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {
                               chrome.tabs.sendMessage(tabs[0].id, {
                                    action: "fontStyle",
-                                   fontStyle: localPrefernce.fontStyle,
+                                   fontStyle: localPreference.fontStyle,
                               });
                          },
                     );
                }
-               if (localPrefernce.image === false) {
+               if (localPreference.image === false) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {
@@ -378,7 +378,7 @@ document
                          },
                     );
                }
-               if (localPrefernce.image === true) {
+               if (localPreference.image === true) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {
@@ -388,19 +388,19 @@ document
                          },
                     );
                }
-               if (localPrefernce.backgroundColor) {
+               if (localPreference.backgroundColor) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {
                               chrome.tabs.sendMessage(tabs[0].id, {
                                    action: "backgroundColor",
                                    backgroundColor:
-                                        localPrefernce.backgroundColor,
+                                        localPreference.backgroundColor,
                               });
                          },
                     );
                }
-               if (localPrefernce.backgroundColor === false) {
+               if (localPreference.backgroundColor === false) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {
@@ -410,18 +410,18 @@ document
                          },
                     );
                }
-               if (localPrefernce.zoomVal) {
+               if (localPreference.zoomVal) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {
                               chrome.tabs.sendMessage(tabs[0].id, {
                                    action: "zoomPage",
-                                   zoomValue: localPrefernce.zoomVal,
+                                   zoomValue: localPreference.zoomVal,
                               });
                          },
                     );
                }
-               if (localPrefernce.paraHighlight === true) {
+               if (localPreference.paraHighlight === true) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {
@@ -431,7 +431,7 @@ document
                          },
                     );
                }
-               if (localPrefernce.paraHighlight === false) {
+               if (localPreference.paraHighlight === false) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {
@@ -441,7 +441,7 @@ document
                          },
                     );
                }
-               if (localPrefernce.linkHighlight === true) {
+               if (localPreference.linkHighlight === true) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {
@@ -451,7 +451,7 @@ document
                          },
                     );
                }
-               if (localPrefernce.linkHighlight === false) {
+               if (localPreference.linkHighlight === false) {
                     chrome.tabs.query(
                          { active: true, currentWindow: true },
                          function (tabs) {

--- a/background.js
+++ b/background.js
@@ -1,6 +1,8 @@
+let prefernce = {}
 const fontBtns = document.getElementsByClassName("fontSize");
 for (let i = 0; i < fontBtns.length; i++) {
   fontBtns[i].addEventListener("click", function (e) {
+    prefernce.fontSize = e.target.innerText;
     console.log("Hi");
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, {
@@ -13,6 +15,7 @@ for (let i = 0; i < fontBtns.length; i++) {
 const fontStyleBtns = document.getElementsByClassName("fontStyle");
 for (let i = 0; i < fontStyleBtns.length; i++) {
   fontStyleBtns[i].addEventListener("click", function (e) {
+    prefernce.fontStyle = e.target.innerText;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, {
         action: "fontStyle",
@@ -25,6 +28,7 @@ for (let i = 0; i < fontStyleBtns.length; i++) {
 const images = document.getElementsByClassName("img-remmover");
 for (let i = 0; i < images.length; i++) {
   images[i].addEventListener("click", function (e) {
+    prefernce.image = false;
     console.log("clicked");
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, { action: "image" });
@@ -35,6 +39,7 @@ for (let i = 0; i < images.length; i++) {
 const imageAdd = document.getElementsByClassName("img-add");
 for (let i = 0; i < imageAdd.length; i++) {
   imageAdd[i].addEventListener("click", function (e) {
+    prefernce.image = true;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, { action: "imageAdd" });
     });
@@ -45,7 +50,9 @@ const textToSpeechHelper = document.getElementsByClassName("text-to-speech");
 const rate = document.querySelector("#rate");
 console.log(rate.value);
 for (let i = 0; i < textToSpeechHelper.length; i++) {
+
   textToSpeechHelper[i].addEventListener("click", function (e) {
+     
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, {
         action: "text-to-speech",
@@ -79,6 +86,7 @@ for (let i = 0; i < textToSpeechStop.length; i++) {
 const links = document.getElementsByClassName("link");
 for (let i = 0; i < links.length; i++) {
   links[i].addEventListener("click", function (e) {
+    prefernce.linkHighlight = true;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, { action: "link-highlight" });
     });
@@ -90,6 +98,7 @@ for (let i = 0; i < links.length; i++) {
 const removeLinkHighlight = document.getElementsByClassName("remove-link-hg");
 for (let i = 0; i < links.length; i++) {
   removeLinkHighlight[i].addEventListener("click", function (e) {
+    prefernce.linkHighlight = false;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, { action: "link-highlight-remove" });
     });
@@ -109,7 +118,9 @@ const backgroundColorChanger = document.getElementById(
   "backgroundColorChanger"
 );
 backgroundColorChanger.addEventListener("submit", function (e) {
+  
   e.preventDefault();
+  prefernce.backgroundColor = e.target.color.value;
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     chrome.tabs.sendMessage(tabs[0].id, {
       action: "backgroundColor",
@@ -121,6 +132,7 @@ backgroundColorChanger.addEventListener("submit", function (e) {
 document
   .getElementsByClassName("revert-background-color")[0]
   .addEventListener("click", function (e) {
+    prefernce.backgroundColor = false;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, {
         action: "revert-background-color",
@@ -131,6 +143,7 @@ document
 const fontColorChanger = document.getElementById("fontColorChanger");
 fontColorChanger.addEventListener("submit", function (e) {
   e.preventDefault();
+  prefernce.fontColor = e.target.color.value;
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     chrome.tabs.sendMessage(tabs[0].id, {
       action: "fontColor",
@@ -142,6 +155,7 @@ fontColorChanger.addEventListener("submit", function (e) {
 const highlightPara = document.getElementsByClassName("para-highlighter");
 for (let i = 0; i < highlightPara.length; i++) {
   highlightPara[i].addEventListener("click", function () {
+    prefernce.paraHighlight = true;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, { action: "para-highlighter" });
     });
@@ -155,6 +169,7 @@ const removeHighlightPara = document.getElementsByClassName(
 );
 for (let i = 0; i < removeHighlightPara.length; i++) {
   removeHighlightPara[i].addEventListener("click", function () {
+    prefernce.paraHighlight = false;
     chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
       chrome.tabs.sendMessage(tabs[0].id, {
         action: "para-highlighter-remove",
@@ -245,6 +260,7 @@ for (let i = 0; i < speakerHelper.length; i++) {
 
 
 function handleZoom(zoomVal) {
+  prefernce.zoomVal = zoomVal;
   chrome.tabs.query({ active: true, currentWindow: true }, function (tabs) {
     chrome.tabs.sendMessage(tabs[0].id, {
       action: "zoomPage",
@@ -306,3 +322,144 @@ for (let i = 0; i < italics_underscore_reset.length; i++) {
     });
   });
 }
+
+const savePrefernceBtn = document
+     .getElementById("savePrefernceBtn")
+     .addEventListener("click", savePrefernce);
+function savePrefernce(e) {
+     //will save prefernces
+     e.preventDefault();
+
+     localStorage.setItem("dinoPrefernces", JSON.stringify(prefernce));
+}
+document.getElementById("clearPrefernceBtn").addEventListener("click", (e) => {
+     e.preventDefault();
+     prefernce = {};
+     localStorage.setItem("dinoPrefernces", JSON.stringify(prefernce));
+}); // will clear all your prefernce
+
+document
+     .getElementById("localStorageToggler")
+     .addEventListener("click", (e) => {
+          let localPrefernce = JSON.parse(
+               localStorage.getItem("dinoPrefernces"),
+          );
+
+          if (localPrefernce) {
+               if (localPrefernce.fontSize) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "fontSize",
+                                   fontSize: localPrefernce.fontSize,
+                              });
+                         },
+                    );
+               }
+               if (localPrefernce.fontStyle) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "fontStyle",
+                                   fontStyle: localPrefernce.fontStyle,
+                              });
+                         },
+                    );
+               }
+               if (localPrefernce.image === false) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "image",
+                              });
+                         },
+                    );
+               }
+               if (localPrefernce.image === true) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "imageAdd",
+                              });
+                         },
+                    );
+               }
+               if (localPrefernce.backgroundColor) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "backgroundColor",
+                                   backgroundColor:
+                                        localPrefernce.backgroundColor,
+                              });
+                         },
+                    );
+               }
+               if (localPrefernce.backgroundColor === false) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "revert-background-color",
+                              });
+                         },
+                    );
+               }
+               if (localPrefernce.zoomVal) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "zoomPage",
+                                   zoomValue: localPrefernce.zoomVal,
+                              });
+                         },
+                    );
+               }
+               if (localPrefernce.paraHighlight === true) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "para-highlighter",
+                              });
+                         },
+                    );
+               }
+               if (localPrefernce.paraHighlight === false) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "para-highlighter-remove",
+                              });
+                         },
+                    );
+               }
+               if (localPrefernce.linkHighlight === true) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "link-highlight",
+                              });
+                         },
+                    );
+               }
+               if (localPrefernce.linkHighlight === false) {
+                    chrome.tabs.query(
+                         { active: true, currentWindow: true },
+                         function (tabs) {
+                              chrome.tabs.sendMessage(tabs[0].id, {
+                                   action: "link-highlight-remove",
+                              });
+                         },
+                    );
+               }
+          }  
+     });

--- a/popup.html
+++ b/popup.html
@@ -28,6 +28,12 @@
       and remove images, read out pages etc.
     </p>
   </section>
+    <section id="localStorage">
+    <h1><span class="speaker">🔊 </span>Your Preferences</h1>
+    <button id="savePrefernceBtn">Save</button>
+    <button id="clearPrefernceBtn">Delete</button>
+    <button id="localStorageToggler">Apply from localStorage</button>
+  </section>
 
   <section id="fonts">
     <h1><span class="speaker">🔊 </span>FONT SIZE</h1>

--- a/popup.html
+++ b/popup.html
@@ -30,8 +30,8 @@
   </section>
     <section id="localStorage">
     <h1><span class="speaker">🔊 </span>Your Preferences</h1>
-    <button id="savePrefernceBtn">Save</button>
-    <button id="clearPrefernceBtn">Delete</button>
+    <button id="savePreferenceBtn">Save</button>
+    <button id="clearPreferenceBtn">Delete</button>
     <button id="localStorageToggler">Apply from localStorage</button>
   </section>
 


### PR DESCRIPTION
<!-- PR template -->

Fixes #82 
# Add an option to save preferences into local storage and use them later

Whenever you choose any option and click on save in Your preferences section, it will save your preferences into local storage, later you can also apply them just by clicking "Apply from localStorage". You can also clear your preferences that are stored in local storage with "Delete" button


# Screenshots (if appropriate):

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

# SWOC Participation
<!-- If you are participating in SWOC 3.0 as a participant please fill these details -->
- Name: Rahul Solanki
- Discord Username: Rahulj9a
- [x] I have included the issue number in my PR
