### PR TITLE
resolve style application on GitHub and complex websites

### DIFF
--- a/webpage-assets/js/content.js
+++ b/webpage-assets/js/content.js
@@ -176,10 +176,38 @@ window.addEventListener(
           ? (backColor =
               document.getElementsByTagName("body")[0].style.backgroundColor)
           : null;
-        document
-          .getElementsByTagName("body")[0]
-          .style.setProperty("background-color", request.backgroundColor);
+        
+        const existingStyle = document.getElementById('dino-custom-styles');
+        if (existingStyle) {
+          existingStyle.remove();
+        }
+        
+        const styleElement = document.createElement('style');
+        styleElement.id = 'dino-custom-styles';
+        styleElement.textContent = `
+          html, body, [data-turbo-body], .application-main, 
+          .Box, .Box-body, .markdown-body, .container, 
+          .main-content, .content, .wrapper, .page, 
+          .layout, .section, .panel, .card, .modal {
+            background-color: ${request.backgroundColor} !important;
+          }
+          * {
+            background-color: transparent !important;
+          }
+          html, body, [data-turbo-body], .application-main, 
+          .Box, .Box-body, .markdown-body, .container, 
+          .main-content, .content, .wrapper, .page, 
+          .layout, .section, .panel, .card, .modal {
+            background-color: ${request.backgroundColor} !important;
+          }
+        `;
+        document.head.appendChild(styleElement);
       } else if (action === "revert-background-color") {
+        // Remove custom styles
+        const customStyle = document.getElementById('dino-custom-styles');
+        if (customStyle) {
+          customStyle.remove();
+        }
         document
           .getElementsByTagName("body")[0]
           .style.setProperty("background-color", backColor);
@@ -188,11 +216,30 @@ window.addEventListener(
         fontColor === ""
           ? (fontColor = document.getElementsByTagName("*")[0].style.fontColor)
           : null;
-        const all = document.getElementsByTagName("*");
-        for (let i = 0; i < all.length; i++) {
-          all[i].style.setProperty("color", request.fontColor);
-        } }
+        
+        const existingFontStyle = document.getElementById('dino-font-styles');
+        if (existingFontStyle) {
+          existingFontStyle.remove();
+        }
+        
+        const fontStyleElement = document.createElement('style');
+        fontStyleElement.id = 'dino-font-styles';
+        fontStyleElement.textContent = `
+          *, body, html, .color-fg-default, .Header-link, 
+          .btn, .Link--primary, .Link--secondary, .f1, .f2, 
+          .f3, .f4, .f5, .f6, h1, h2, h3, h4, h5, h6, 
+          p, span, div, a, button, input, textarea, select, 
+          label, li, td, th {
+            color: ${request.fontColor} !important;
+          }
+        `;
+          document.head.appendChild(fontStyleElement);
+        }
         else if (action === "revert-Font-color") {
+          const customFontStyle = document.getElementById('dino-font-styles');
+          if (customFontStyle) {
+            customFontStyle.remove();
+          }
           const all = document.getElementsByTagName("*")[0];
           all.style.setProperty("color", fontColor);
             


### PR DESCRIPTION
<!-- PR template -->

Fixes #174
# Description

Fixed the issue where selected style options (background color, font color) were not being applied on GitHub and other complex websites. 

**Problem**: GitHub's nested DOM structure and high CSS specificity prevented Dino's style changes from working properly. The existing approach only targeted basic elements like `body` and `*`, which was insufficient.

**Solution Implemented**:
- **CSS Injection System**: Created comprehensive `<style>` elements with unique IDs for proper cleanup
- **High-Specificity Selectors**: Added GitHub-specific container targeting including `.application-main`, `.Box`, `.Box-body`, `.markdown-body`, `.container`, `.main-content`, etc.
- **Important Declarations**: Used `!important` to override GitHub's existing styles
- **Font Color Coverage**: Enhanced font color application to target all GitHub UI components like `.color-fg-default`, `.Header-link`, `.btn`, `.Link--primary`, etc.
- **Style Management**: Added proper removal of custom styles when reverting changes

**Files Modified**:
- `webpage-assets/js/content.js` (lines 174-241): Enhanced backgroundColor and fontColor actions

The fix ensures that background and font color changes now work correctly across all GitHub pages and similar complex websites with nested structures.


# Screenshots 
Before 
<img width="1587" height="906" alt="Screenshot 2026-02-06 001150" src="https://github.com/user-attachments/assets/cc93dc71-c797-4362-94a1-086429ad5b2e" />

After
<img width="1545" height="973" alt="Screenshot 2026-02-06 001517" src="https://github.com/user-attachments/assets/ba0a9382-434b-45e8-b1d1-27886370060a" />


**Before Fix**:
- GitHub repository page with background color selected but NOT applied
- Extension popup showing selected color
- GitHub still showing default white background

**After Fix**:
- Same GitHub repository page with background color SUCCESSFULLY applied
- All nested containers (header, sidebar, main content) showing the new color
- Font color changes working on GitHub links and buttons

# Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

# Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.

# I am a Apertre3.0 Participant 
- Name: Soumojit Das
- Discord Username: soumojit010
- [x] I have included the issue number in my PR


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated how background color and font color customizations are applied to the webpage.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->